### PR TITLE
feat: display downloaded/monitored state in `!addmovie` / `!addshow`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 config.yaml
 !tests/config.yaml
 log/
-
+__pycache__/
 dist/
 .direnv/
 .vscode/

--- a/arr/src/wi1_bot/arr/__init__.py
+++ b/arr/src/wi1_bot/arr/__init__.py
@@ -1,6 +1,6 @@
-from wi1_bot.arr.common import Download, ImportMode
+from wi1_bot.arr.common import Download, ImportMode, MediaState
 from wi1_bot.arr.config import ArrConfig
 from wi1_bot.arr.radarr import Radarr
 from wi1_bot.arr.sonarr import Sonarr
 
-__all__ = ["ArrConfig", "Download", "ImportMode", "Radarr", "Sonarr"]
+__all__ = ["ArrConfig", "Download", "ImportMode", "MediaState", "Radarr", "Sonarr"]

--- a/arr/src/wi1_bot/arr/common.py
+++ b/arr/src/wi1_bot/arr/common.py
@@ -11,6 +11,12 @@ class ImportMode(IntEnum):
     COPY = 2
 
 
+class MediaState(IntEnum):
+    ABSENT = 0
+    MONITORED = 1
+    DOWNLOADED = 2
+
+
 class Download:
     def __init__(self, data: dict[str, Any]) -> None:
         self.content: Movie | Episode | str

--- a/arr/src/wi1_bot/arr/radarr.py
+++ b/arr/src/wi1_bot/arr/radarr.py
@@ -7,7 +7,7 @@ from pyarr.types import JsonArray, JsonObject
 
 from wi1_bot.arr.config import ArrConfig
 
-from .common import Download, ImportMode
+from .common import Download, ImportMode, MediaState
 from .movie import Movie
 
 __all__ = ["Movie", "Radarr"]
@@ -97,6 +97,26 @@ class Radarr:
         files = self._radarr.movie_file.get(movie_id=potential[0]["id"])
 
         return len(files) > 0
+
+    def movie_state(self, movie: Movie) -> MediaState:
+        """Classify a looked-up movie as ABSENT, MONITORED, or DOWNLOADED.
+
+        When Radarr already tracks a movie, lookup returns the library record itself
+        (this is what :meth:`lookup_library` filters on), so ``id``, ``movieFileId``
+        and ``monitored`` are all in the lookup result — no extra API calls. Don't use
+        ``hasFile`` here: only the ``/movie`` controller populates it (from
+        statistics), so lookup results always report it null/false.
+        """
+        if "id" not in movie.json:
+            return MediaState.ABSENT
+
+        if movie.json.get("movieFileId", 0) > 0:
+            return MediaState.DOWNLOADED
+
+        if movie.json.get("monitored"):
+            return MediaState.MONITORED
+
+        return MediaState.ABSENT
 
     def create_tag(self, tag: str) -> None:
         self._radarr.tag.create(label=tag)

--- a/arr/src/wi1_bot/arr/sonarr.py
+++ b/arr/src/wi1_bot/arr/sonarr.py
@@ -7,7 +7,7 @@ from pyarr.types import JsonArray, JsonObject
 
 from wi1_bot.arr.config import ArrConfig
 
-from .common import Download, ImportMode
+from .common import Download, ImportMode, MediaState
 
 
 class Series:
@@ -129,6 +129,24 @@ class Sonarr:
         assert isinstance(files, list)
 
         return len(files) > 0
+
+    def series_state(self, series: Series) -> MediaState:
+        """Classify a looked-up series as ABSENT, MONITORED, or DOWNLOADED.
+
+        A series lookup carries the library ``id`` (``series.db_id``) when Sonarr
+        already tracks it, but blanks ``statistics``, so each in-library result costs
+        one series fetch to see whether any episode files exist.
+        """
+        if series.db_id is None:
+            return MediaState.ABSENT
+
+        if self.get_series_by_id(series.db_id)["statistics"]["episodeFileCount"] > 0:
+            return MediaState.DOWNLOADED
+
+        if series.json.get("monitored"):
+            return MediaState.MONITORED
+
+        return MediaState.ABSENT
 
     def create_tag(self, tag: str) -> None:
         self._sonarr.tag.create(label=tag)

--- a/arr/tests/test_arr_state.py
+++ b/arr/tests/test_arr_state.py
@@ -1,0 +1,106 @@
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wi1_bot.arr.common import MediaState
+from wi1_bot.arr.movie import Movie
+from wi1_bot.arr.radarr import Radarr
+from wi1_bot.arr.sonarr import Series, Sonarr
+
+
+class TestMovieState:
+    @pytest.fixture
+    def radarr(self) -> Radarr:
+        with patch("wi1_bot.arr.radarr.RadarrClient"):
+            return Radarr("http://localhost:7878", "fake-api-key")
+
+    @pytest.fixture
+    def base_json(self) -> dict[str, Any]:
+        return {"title": "The Matrix", "year": 1999, "tmdbId": 603, "imdbId": "tt0133093"}
+
+    def test_absent_when_not_in_library(self, radarr: Radarr, base_json: dict[str, Any]) -> None:
+        # no library "id" -> ABSENT
+        assert radarr.movie_state(Movie(base_json)) is MediaState.ABSENT
+
+    def test_downloaded_when_movie_file_exists(
+        self, radarr: Radarr, base_json: dict[str, Any]
+    ) -> None:
+        # lookup returns the library record itself, so movieFileId is read straight
+        # off it (hasFile is only populated by the /movie controller, not lookup)
+        movie = Movie({**base_json, "id": 1, "monitored": True, "movieFileId": 9})
+
+        assert radarr.movie_state(movie) is MediaState.DOWNLOADED
+
+    def test_monitored_when_in_library_without_files(
+        self, radarr: Radarr, base_json: dict[str, Any]
+    ) -> None:
+        movie = Movie({**base_json, "id": 1, "monitored": True, "movieFileId": 0})
+
+        assert radarr.movie_state(movie) is MediaState.MONITORED
+
+    def test_absent_when_in_library_unmonitored_without_files(
+        self, radarr: Radarr, base_json: dict[str, Any]
+    ) -> None:
+        movie = Movie({**base_json, "id": 1, "monitored": False, "movieFileId": 0})
+
+        assert radarr.movie_state(movie) is MediaState.ABSENT
+
+    def test_state_never_calls_api(self, radarr: Radarr, base_json: dict[str, Any]) -> None:
+        # every state is derived from the lookup json alone
+        radarr._radarr.movie.get = MagicMock()
+        radarr._radarr.movie_file.get = MagicMock()
+
+        for extra in ({}, {"id": 1, "monitored": True, "movieFileId": 9}):
+            radarr.movie_state(Movie({**base_json, **extra}))
+
+        radarr._radarr.movie.get.assert_not_called()  # ty: ignore[unresolved-attribute]
+        radarr._radarr.movie_file.get.assert_not_called()  # ty: ignore[unresolved-attribute]
+
+
+class TestSeriesState:
+    @pytest.fixture
+    def sonarr(self) -> Sonarr:
+        with patch("wi1_bot.arr.sonarr.SonarrClient"):
+            return Sonarr("http://localhost:8989", "fake-api-key")
+
+    @pytest.fixture
+    def base_json(self) -> dict[str, Any]:
+        return {"title": "Burn Notice", "year": 2007, "tvdbId": 82064, "imdbId": "tt0810788"}
+
+    @staticmethod
+    def _series_detail(episode_file_count: int) -> dict[str, Any]:
+        return {"id": 1, "statistics": {"episodeFileCount": episode_file_count}}
+
+    def test_absent_when_not_in_library(self, sonarr: Sonarr, base_json: dict[str, Any]) -> None:
+        # no library "id" -> db_id is None -> ABSENT without touching the API
+        sonarr._sonarr.series.get = MagicMock()
+
+        assert sonarr.series_state(Series(base_json)) is MediaState.ABSENT
+        sonarr._sonarr.series.get.assert_not_called()  # ty: ignore[unresolved-attribute]
+
+    def test_downloaded_when_episode_files_exist(
+        self, sonarr: Sonarr, base_json: dict[str, Any]
+    ) -> None:
+        series = Series({**base_json, "id": 1, "monitored": True})
+        sonarr._sonarr.series.get = MagicMock(return_value=self._series_detail(42))
+
+        assert sonarr.series_state(series) is MediaState.DOWNLOADED
+        get = sonarr._sonarr.series.get
+        get.assert_called_once_with(item_id=1)  # ty: ignore[unresolved-attribute]
+
+    def test_monitored_when_in_library_without_files(
+        self, sonarr: Sonarr, base_json: dict[str, Any]
+    ) -> None:
+        series = Series({**base_json, "id": 1, "monitored": True})
+        sonarr._sonarr.series.get = MagicMock(return_value=self._series_detail(0))
+
+        assert sonarr.series_state(series) is MediaState.MONITORED
+
+    def test_absent_when_in_library_unmonitored_without_files(
+        self, sonarr: Sonarr, base_json: dict[str, Any]
+    ) -> None:
+        series = Series({**base_json, "id": 1, "monitored": False})
+        sonarr._sonarr.series.get = MagicMock(return_value=self._series_detail(0))
+
+        assert sonarr.series_state(series) is MediaState.ABSENT

--- a/arr/tests/test_arr_state.py
+++ b/arr/tests/test_arr_state.py
@@ -54,8 +54,8 @@ class TestMovieState:
         for extra in ({}, {"id": 1, "monitored": True, "movieFileId": 9}):
             radarr.movie_state(Movie({**base_json, **extra}))
 
-        radarr._radarr.movie.get.assert_not_called()  # ty: ignore[unresolved-attribute]
-        radarr._radarr.movie_file.get.assert_not_called()  # ty: ignore[unresolved-attribute]
+        radarr._radarr.movie.get.assert_not_called()
+        radarr._radarr.movie_file.get.assert_not_called()
 
 
 class TestSeriesState:
@@ -77,7 +77,7 @@ class TestSeriesState:
         sonarr._sonarr.series.get = MagicMock()
 
         assert sonarr.series_state(Series(base_json)) is MediaState.ABSENT
-        sonarr._sonarr.series.get.assert_not_called()  # ty: ignore[unresolved-attribute]
+        sonarr._sonarr.series.get.assert_not_called()
 
     def test_downloaded_when_episode_files_exist(
         self, sonarr: Sonarr, base_json: dict[str, Any]
@@ -86,8 +86,7 @@ class TestSeriesState:
         sonarr._sonarr.series.get = MagicMock(return_value=self._series_detail(42))
 
         assert sonarr.series_state(series) is MediaState.DOWNLOADED
-        get = sonarr._sonarr.series.get
-        get.assert_called_once_with(item_id=1)  # ty: ignore[unresolved-attribute]
+        sonarr._sonarr.series.get.assert_called_once_with(item_id=1)
 
     def test_monitored_when_in_library_without_files(
         self, sonarr: Sonarr, base_json: dict[str, Any]

--- a/bot/src/wi1_bot/bot/discord/cogs/movie.py
+++ b/bot/src/wi1_bot/bot/discord/cogs/movie.py
@@ -7,7 +7,7 @@ from wi1_bot.arr.radarr import Movie, Radarr
 from wi1_bot.bot.config import config
 from wi1_bot.common import push
 
-from ..helpers import member_has_role, reply, select_from_list
+from ..helpers import STATE_SUFFIX, member_has_role, reply, select_from_list
 
 
 class MovieCog(commands.Cog):
@@ -33,7 +33,17 @@ class MovieCog(commands.Cog):
                 )
                 return
 
-        resp, to_add = await select_from_list(self.bot, ctx.message, "addmovie", potential)
+            # resolve each result's state up front so the picker can show what's already
+            # on plex / monitored before the user commits to adding it
+            states = {movie: self.radarr.movie_state(movie) for movie in potential}
+
+        resp, to_add = await select_from_list(
+            self.bot,
+            ctx.message,
+            "addmovie",
+            potential,
+            render=lambda movie: f"{movie}{STATE_SUFFIX[states[movie]]}",
+        )
 
         if not to_add:
             return

--- a/bot/src/wi1_bot/bot/discord/cogs/series.py
+++ b/bot/src/wi1_bot/bot/discord/cogs/series.py
@@ -7,7 +7,7 @@ from wi1_bot.arr.sonarr import Series, Sonarr, SonarrError
 from wi1_bot.bot.config import config
 from wi1_bot.common import push
 
-from ..helpers import member_has_role, reply, select_from_list
+from ..helpers import STATE_SUFFIX, member_has_role, reply, select_from_list
 
 
 class SeriesCog(commands.Cog):
@@ -42,7 +42,17 @@ class SeriesCog(commands.Cog):
                 )
                 return
 
-        resp, to_add = await select_from_list(self.bot, ctx.message, "addshow", potential)
+            # resolve each result's state up front so the picker can show what's already
+            # on plex / monitored before the user commits to adding it
+            states = {series: self.sonarr.series_state(series) for series in potential}
+
+        resp, to_add = await select_from_list(
+            self.bot,
+            ctx.message,
+            "addshow",
+            potential,
+            render=lambda series: f"{series}{STATE_SUFFIX[states[series]]}",
+        )
 
         if not to_add:
             return

--- a/bot/src/wi1_bot/bot/discord/helpers.py
+++ b/bot/src/wi1_bot/bot/discord/helpers.py
@@ -1,9 +1,21 @@
 import asyncio
 import re
+from collections.abc import Callable
 from typing import TypeVar
 
 import discord
 from discord.ext import commands
+
+from wi1_bot.arr import MediaState
+
+# suffix appended to a choice in an add-list so users can see, before they pick, whether
+# a title is already downloaded ("on plex") or monitored (queued to download). ABSENT
+# titles get nothing so they read as a normal search result.
+STATE_SUFFIX: dict[MediaState, str] = {
+    MediaState.ABSENT: "",
+    MediaState.MONITORED: " — *monitored*",
+    MediaState.DOWNLOADED: " — **on plex**",
+}
 
 
 async def member_has_role(member: discord.Member | discord.User, role: str) -> bool:
@@ -33,9 +45,13 @@ T = TypeVar("T")
 
 
 async def select_from_list(
-    bot: commands.Bot, msg: discord.Message, command: str, choices: list[T]
+    bot: commands.Bot,
+    msg: discord.Message,
+    command: str,
+    choices: list[T],
+    render: Callable[[T], str] = str,
 ) -> tuple[discord.Message, list[T]]:
-    choices_text = "\n".join(f"{i + 1}. {choice}" for i, choice in enumerate(choices))
+    choices_text = "\n".join(f"{i + 1}. {render(choice)}" for i, choice in enumerate(choices))
 
     await reply(
         msg,


### PR DESCRIPTION
## Summary

When a user starts a request (`!addmovie`, `!addshow`), the selection list now reflects each result's current state so they can see whether a title is already available or on the way before picking:

- `— on plex` — the title is in Radarr/Sonarr and has media files (downloaded).
- `— monitored` — the title is in the library and monitored (will download when available) but has no files yet.
- no suffix — not in the library; reads as a normal search result.

## Example

`!addmovie Odyssey`:
```
1. The Odyssey (2026) — monitored
2. 2001: A Space Odyssey (1968) — on plex
3. Odyssey (2025)
```
This surfaces state at request time and leaves the existing post-selection message `already DOWNLOADED on the plex (idiot)` unchanged, and especially demeaning now.

## How it works

When a lookup is already in the library, both arrs return the library record itself from `/lookup` (their `MapSearchResult` returns the DB entity when `FindByTmdbId`/`FindByTvdbId` hits), so `id` and `monitored` come straight from the lookup result. Results without an `id` are `ABSENT` and cost zero extra API calls.

State differs per app:

- Radarr: the lookup result already carries `movieFileId` (mapped from the DB record
  in `MovieResource.ToResource`), so movie state costs zero extra API calls.
- Sonarr: `SeriesLookupController` deliberately blanks `statistics` on lookup
  results, so each in-library result costs one `GET /series/{id}` and reads
  `statistics.episodeFileCount` — a single small object.