### PR TITLE
feat: add !movieinfo and !showinfo commands + react to request

### DIFF
--- a/arr/src/wi1_bot/arr/movie.py
+++ b/arr/src/wi1_bot/arr/movie.py
@@ -13,13 +13,11 @@ class Movie:
 
         self.url = f"https://themoviedb.org/movie/{self.tmdb_id}"
 
-        self.imdb_id: str = ""
+        # prefer an imdb link, but the api can return imdbId as "" as well as omit it
+        self.imdb_id: str = movie_json.get("imdbId") or ""
 
-        try:
-            self.imdb_id = movie_json["imdbId"]
+        if self.imdb_id:
             self.url = f"https://imdb.com/title/{self.imdb_id}"
-        except KeyError:
-            pass
 
     def __str__(self) -> str:
         return f"[{self.full_title}]({self.url})"

--- a/arr/src/wi1_bot/arr/radarr.py
+++ b/arr/src/wi1_bot/arr/radarr.py
@@ -191,6 +191,13 @@ class Radarr:
         assert isinstance(movie, dict)
         return movie
 
+    def get_movie_credits(self, movie_id: int) -> JsonArray:
+        """Cast/crew Radarr has stored for a library movie (empty for movies it
+        doesn't track). pyarr has no credit sub-client, so go through the handler."""
+        credits = self._radarr.movie.handler.request("credit", params={"movieId": movie_id})
+        assert isinstance(credits, list)
+        return credits
+
     def is_movie_monitored(self, tmdb_id: int) -> bool:
         movies = self._radarr.movie.get(tmdb_id=tmdb_id)
         assert isinstance(movies, list)

--- a/arr/src/wi1_bot/arr/sonarr.py
+++ b/arr/src/wi1_bot/arr/sonarr.py
@@ -24,13 +24,11 @@ class Series:
 
         self.url = f"https://thetvdb.com/dereferrer/series/{self.tvdb_id}"
 
-        self.imdb_id = ""
+        # prefer an imdb link, but the api can return imdbId as "" as well as omit it
+        self.imdb_id: str = series_json.get("imdbId") or ""
 
-        try:
-            self.imdb_id = series_json["imdbId"]
+        if self.imdb_id:
             self.url = f"https://imdb.com/title/{self.imdb_id}"
-        except KeyError:
-            pass
 
     def __str__(self) -> str:
         return f"[{self.full_title}]({self.url})"

--- a/arr/tests/test_arr_integration.py
+++ b/arr/tests/test_arr_integration.py
@@ -159,6 +159,24 @@ class TestRadarr:
         with pytest.raises(ValueError, match="no quality profile with the name bad"):
             radarr._get_quality_profile_id("bad")
 
+    def test_get_movie_credits(self, radarr: Radarr) -> None:
+        credits = [
+            {"personName": "Keanu Reeves", "personTmdbId": 6384, "type": "cast", "order": 0},
+            {
+                "personName": "Lana Wachowski",
+                "personTmdbId": 9339,
+                "type": "crew",
+                "job": "Director",
+            },
+        ]
+
+        radarr._radarr.movie.handler.request = MagicMock(return_value=credits)
+
+        assert radarr.get_movie_credits(1) == credits
+        radarr._radarr.movie.handler.request.assert_called_once_with(
+            "credit", params={"movieId": 1}
+        )
+
 
 class TestSonarr:
     @pytest.fixture

--- a/arr/tests/test_arr_models.py
+++ b/arr/tests/test_arr_models.py
@@ -1,6 +1,7 @@
 from wi1_bot.arr.common import Download
 from wi1_bot.arr.episode import Episode
 from wi1_bot.arr.movie import Movie
+from wi1_bot.arr.sonarr import Series
 
 
 class TestMovie:
@@ -35,6 +36,20 @@ class TestMovie:
         assert movie.full_title == "Inception (2010)"
         assert movie.url == "https://themoviedb.org/movie/27205"
 
+    def test_movie_creation_with_empty_imdb(self) -> None:
+        # the api can return imdbId as "" instead of omitting it; the url should
+        # still fall back instead of linking to https://imdb.com/title/
+        movie_json = {
+            "title": "Inception",
+            "year": 2010,
+            "tmdbId": 27205,
+            "imdbId": "",
+        }
+        movie = Movie(movie_json)
+
+        assert movie.imdb_id == ""
+        assert movie.url == "https://themoviedb.org/movie/27205"
+
     def test_movie_str_representation(self) -> None:
         movie_json = {
             "title": "The Matrix",
@@ -45,6 +60,45 @@ class TestMovie:
         movie = Movie(movie_json)
 
         assert str(movie) == "[The Matrix (1999)](https://imdb.com/title/tt0133093)"
+
+
+class TestSeries:
+    def test_series_creation_with_imdb(self) -> None:
+        series_json = {
+            "title": "Game of Thrones",
+            "year": 2011,
+            "tvdbId": 121361,
+            "imdbId": "tt0944947",
+        }
+        series = Series(series_json)
+
+        assert series.imdb_id == "tt0944947"
+        assert series.url == "https://imdb.com/title/tt0944947"
+
+    def test_series_creation_without_imdb(self) -> None:
+        series_json = {
+            "title": "Game of Thrones",
+            "year": 2011,
+            "tvdbId": 121361,
+        }
+        series = Series(series_json)
+
+        assert series.imdb_id == ""
+        assert series.url == "https://thetvdb.com/dereferrer/series/121361"
+
+    def test_series_creation_with_empty_imdb(self) -> None:
+        # sonarr lookups commonly return imdbId as ""; the url should still fall
+        # back to tvdb instead of linking to https://imdb.com/title/
+        series_json = {
+            "title": "Game of Thrones",
+            "year": 2011,
+            "tvdbId": 121361,
+            "imdbId": "",
+        }
+        series = Series(series_json)
+
+        assert series.imdb_id == ""
+        assert series.url == "https://thetvdb.com/dereferrer/series/121361"
 
 
 class TestEpisode:

--- a/bot/config.yaml.template
+++ b/bot/config.yaml.template
@@ -44,6 +44,11 @@ discord:
         - OTHER_USER_ID1
         - OTHER_USER_ID2
 
+# tmdb settings, optional (enables cast/director info in !movieinfo and !showinfo)
+tmdb:
+  # tmdb api key (v3, https://www.themoviedb.org/settings/api)
+  api_key: XXX
+
 # pushover settings, optional
 pushover:
   # pushover user key

--- a/bot/pyproject.toml
+++ b/bot/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pydantic>=2.13.4",
     "pydantic-settings>=2.14.2",
     "pyyaml>=6.0.3",
+    "requests>=2.31.0",
 ]
 
 [project.scripts]

--- a/bot/src/wi1_bot/bot/config.py
+++ b/bot/src/wi1_bot/bot/config.py
@@ -13,6 +13,10 @@ class GeneralConfig(BaseModel):
     )
 
 
+class TmdbConfig(BaseModel):
+    api_key: str = Field(min_length=1, description="TMDB API key (v3)")
+
+
 class Quota(BaseModel):
     amount: float = Field(gt=0, description="Quota amount in GB")
     with_: list[int] = Field(
@@ -66,6 +70,7 @@ class Config(BaseServiceConfig):
     sonarr: ArrConfig
     discord: DiscordConfig
     pushover: PushoverConfig | None = None
+    tmdb: TmdbConfig | None = None
 
 
 config = Config()  # type: ignore[call-arg]

--- a/bot/src/wi1_bot/bot/discord/cogs/movie.py
+++ b/bot/src/wi1_bot/bot/discord/cogs/movie.py
@@ -1,13 +1,26 @@
 import asyncio
 import logging
 
+import discord
+import requests
 from discord.ext import commands
 
+from wi1_bot.arr import MediaState
 from wi1_bot.arr.radarr import Movie, Radarr
 from wi1_bot.bot.config import config
+from wi1_bot.bot.tmdb import MAX_CAST, Credits, Person, Tmdb
 from wi1_bot.common import push
 
-from ..helpers import STATE_SUFFIX, member_has_role, reply, select_from_list
+from ..helpers import (
+    REQUEST_EMOJI,
+    STATE_LABEL,
+    STATE_SUFFIX,
+    format_runtime,
+    member_has_role,
+    reply,
+    select_from_list,
+    wait_for_request_reaction,
+)
 
 
 class MovieCog(commands.Cog):
@@ -15,6 +28,7 @@ class MovieCog(commands.Cog):
         self.bot = bot
         self.logger = logging.getLogger(__name__)
         self.radarr = Radarr.from_config(config.radarr)
+        self.tmdb = Tmdb.from_config(config.tmdb)
 
     @commands.command(name="addmovie", help="add a movie to the plex")
     async def addmovie_cmd(self, ctx: commands.Context[commands.Bot], *, query: str = "") -> None:
@@ -48,6 +62,15 @@ class MovieCog(commands.Cog):
         if not to_add:
             return
 
+        await self._add_movies(resp, to_add, ctx.message.author)
+
+    async def _add_movies(
+        self,
+        resp: discord.Message,
+        to_add: list[Movie],
+        requester: discord.Member | discord.User,
+        announce_requester: bool = False,
+    ) -> None:
         added: list[Movie] = []
 
         for movie in to_add:
@@ -58,15 +81,20 @@ class MovieCog(commands.Cog):
                     await reply(resp, f"{movie} is already on the plex (idiot)")
                 continue
 
-            self.logger.info(f"{ctx.message.author.name} has added the movie {movie.full_title}")
+            self.logger.info(f"{requester.name} has added the movie {movie.full_title}")
 
             push.send(
                 config.pushover,
-                f"{ctx.message.author.name} has added the movie {movie.full_title}",
+                f"{requester.name} has added the movie {movie.full_title}",
                 url=movie.url,
             )
 
-            await reply(resp, f"added movie {movie} to the plex")
+            msg = f"added movie {movie} to the plex"
+
+            if announce_requester:
+                msg += f" (requested by {requester.display_name})"
+
+            await reply(resp, msg)
 
             added.append(movie)
 
@@ -75,15 +103,163 @@ class MovieCog(commands.Cog):
 
         await asyncio.sleep(10)
 
-        if not self.radarr.add_tag(added, ctx.message.author.id):
+        if not self.radarr.add_tag(added, requester.id):
             push.send(
                 config.pushover,
-                f"get {ctx.message.author.name} a tag",
+                f"get {requester.name} a tag",
                 title="tag needed",
                 priority=1,
             )
 
-            await ctx.send(f"hey <@!{config.discord.admin_id}> get this guy a tag")
+            await resp.channel.send(f"hey <@!{config.discord.admin_id}> get this guy a tag")
+
+    @commands.command(name="movieinfo", help="get information about a movie")
+    async def movieinfo_cmd(self, ctx: commands.Context[commands.Bot], *, query: str = "") -> None:
+        if not query:
+            await reply(ctx.message, "usage: !movieinfo KEYWORDS...")
+            return
+
+        async with ctx.typing():
+            potential = self.radarr.lookup_movie(query)
+
+            if not potential:
+                await reply(
+                    ctx.message,
+                    f"could not find a movie matching the query: {query}",
+                    error=True,
+                )
+                return
+
+        resp, selected = await select_from_list(self.bot, ctx.message, "movieinfo", potential)
+
+        if not selected:
+            return
+
+        offers: list[asyncio.Task[None]] = []
+
+        for movie in selected:
+            async with ctx.typing():
+                state = self.radarr.movie_state(movie)
+                embed = self._build_movie_embed(movie, state)
+
+            info_msg = await resp.reply(embed=embed)
+
+            if state is MediaState.ABSENT:
+                # each offer waits for a request reaction; run them as tasks so
+                # multiple selections don't wait serially
+                offers.append(asyncio.create_task(self._offer_movie_request(info_msg, movie)))
+
+        if offers:
+            await asyncio.gather(*offers)
+
+    async def _offer_movie_request(self, info_msg: discord.Message, movie: Movie) -> None:
+        user = await wait_for_request_reaction(self.bot, info_msg)
+
+        if user is None:
+            return
+
+        self.logger.info(f"{user.name} requested the movie {movie.full_title} via reaction")
+
+        await self._add_movies(info_msg, [movie], user, announce_requester=True)
+
+    def _movie_credits(self, movie: Movie) -> Credits | None:
+        if self.tmdb is not None:
+            try:
+                return self.tmdb.movie_credits(movie.tmdb_id)
+            except requests.RequestException:
+                self.logger.warning(
+                    f"failed to fetch tmdb credits for {movie.full_title}", exc_info=True
+                )
+
+        # without tmdb, radarr itself stores credits for library movies (only tmdb
+        # person links though, no imdb ids)
+        if "id" not in movie.json:
+            return None
+
+        credits = self.radarr.get_movie_credits(movie.json["id"])
+
+        directors = [
+            Person(c["personName"], c["personTmdbId"])
+            for c in credits
+            if c["type"] == "crew" and c.get("job") == "Director"
+        ]
+        cast = sorted((c for c in credits if c["type"] == "cast"), key=lambda c: c.get("order", 0))
+
+        return Credits(
+            directors=directors,
+            cast=[Person(c["personName"], c["personTmdbId"]) for c in cast[:MAX_CAST]],
+        )
+
+    def _build_movie_embed(self, movie: Movie, state: MediaState) -> discord.Embed:
+        json = movie.json
+
+        overview: str = json.get("overview", "")
+
+        embed = discord.Embed(
+            title=movie.full_title,
+            url=movie.url,
+            description=overview[:1024],
+            color=discord.Color.blue(),
+        )
+
+        if poster := json.get("remotePoster"):
+            embed.set_thumbnail(url=poster)
+
+        if runtime := json.get("runtime"):
+            embed.add_field(name="runtime", value=format_runtime(runtime), inline=False)
+
+        if genres := json.get("genres"):
+            embed.add_field(name="genres", value=", ".join(genres), inline=False)
+
+        if studio := json.get("studio"):
+            embed.add_field(name="studio", value=studio, inline=False)
+
+        if certification := json.get("certification"):
+            embed.add_field(name="rated", value=certification, inline=False)
+
+        ratings = json.get("ratings") or {}
+        rating_parts: list[str] = []
+
+        # sources with no rating yet report value 0, so filter those out too
+        if (imdb := ratings.get("imdb")) and imdb["value"]:
+            rating_parts.append(f"imdb {imdb['value']:.1f}/10")
+        if (tmdb := ratings.get("tmdb")) and tmdb["value"]:
+            rating_parts.append(f"tmdb {tmdb['value']:.1f}/10")
+        if (rt := ratings.get("rottenTomatoes")) and rt["value"]:
+            rating_parts.append(f"rt {rt['value']:.0f}%")
+        if (metacritic := ratings.get("metacritic")) and metacritic["value"]:
+            rating_parts.append(f"metacritic {metacritic['value']:.0f}/100")
+
+        embed.add_field(
+            name="ratings",
+            value=" | ".join(rating_parts) if rating_parts else "unrated",
+            inline=False,
+        )
+
+        if credits := self._movie_credits(movie):
+            if credits.directors:
+                embed.add_field(
+                    name="director", value=", ".join(map(str, credits.directors)), inline=False
+                )
+            if credits.cast:
+                embed.add_field(name="cast", value=", ".join(map(str, credits.cast)), inline=False)
+
+        embed.add_field(name="status", value=STATE_LABEL[state], inline=False)
+
+        if state is MediaState.DOWNLOADED:
+            detail = self.radarr.get_movie_by_id(json["id"])
+
+            if movie_file := detail.get("movieFile"):
+                embed.add_field(
+                    name="quality", value=movie_file["quality"]["quality"]["name"], inline=False
+                )
+
+            if size := detail.get("sizeOnDisk"):
+                embed.add_field(name="size", value=f"{size / 1024**3:.2f} GB", inline=False)
+        elif state is MediaState.ABSENT:
+            embed.set_footer(text=f"react {REQUEST_EMOJI} to request this movie")
+
+        return embed
 
     @commands.command(name="delmovie", help="delete a movie from the plex")
     async def delmovie_cmd(self, ctx: commands.Context[commands.Bot], *, query: str = "") -> None:

--- a/bot/src/wi1_bot/bot/discord/cogs/series.py
+++ b/bot/src/wi1_bot/bot/discord/cogs/series.py
@@ -1,13 +1,26 @@
 import asyncio
 import logging
 
+import discord
+import requests
 from discord.ext import commands
 
+from wi1_bot.arr import MediaState
 from wi1_bot.arr.sonarr import Series, Sonarr, SonarrError
 from wi1_bot.bot.config import config
+from wi1_bot.bot.tmdb import SeriesDetails, Tmdb
 from wi1_bot.common import push
 
-from ..helpers import STATE_SUFFIX, member_has_role, reply, select_from_list
+from ..helpers import (
+    REQUEST_EMOJI,
+    STATE_LABEL,
+    STATE_SUFFIX,
+    format_runtime,
+    member_has_role,
+    reply,
+    select_from_list,
+    wait_for_request_reaction,
+)
 
 
 class SeriesCog(commands.Cog):
@@ -15,6 +28,7 @@ class SeriesCog(commands.Cog):
         self.bot = bot
         self.logger = logging.getLogger(__name__)
         self.sonarr = Sonarr.from_config(config.sonarr)
+        self.tmdb = Tmdb.from_config(config.tmdb)
 
     @commands.command(name="addshow", help="add a show to the plex")
     @commands.has_any_role("plex-admin", "plex-shows")
@@ -57,6 +71,15 @@ class SeriesCog(commands.Cog):
         if not to_add:
             return
 
+        await self._add_series(resp, to_add, ctx.message.author)
+
+    async def _add_series(
+        self,
+        resp: discord.Message,
+        to_add: list[Series],
+        requester: discord.Member | discord.User,
+        announce_requester: bool = False,
+    ) -> None:
         added: list[Series] = []
 
         for series in to_add:
@@ -67,15 +90,20 @@ class SeriesCog(commands.Cog):
                     await reply(resp, f"{series} is already on the plex (idiot)")
                 continue
 
-            self.logger.info(f"{ctx.message.author.name} has added the show {series.full_title}")
+            self.logger.info(f"{requester.name} has added the show {series.full_title}")
 
             push.send(
                 config.pushover,
-                f"{ctx.message.author.name} has added the show {series.full_title}",
+                f"{requester.name} has added the show {series.full_title}",
                 url=series.url,
             )
 
-            await reply(resp, f"added show {series} to the plex")
+            msg = f"added show {series} to the plex"
+
+            if announce_requester:
+                msg += f" (requested by {requester.display_name})"
+
+            await reply(resp, msg)
 
             added.append(series)
 
@@ -85,17 +113,185 @@ class SeriesCog(commands.Cog):
         await asyncio.sleep(10)
 
         for series in added:
-            if not self.sonarr.add_tag(series, ctx.message.author.id):
+            if not self.sonarr.add_tag(series, requester.id):
                 push.send(
                     config.pushover,
-                    f"get {ctx.message.author.name} a tag",
+                    f"get {requester.name} a tag",
                     title="tag needed",
                     priority=1,
                 )
 
-                await ctx.send(f"hey <@!{config.discord.admin_id}> get this guy a tag")
+                await resp.channel.send(f"hey <@!{config.discord.admin_id}> get this guy a tag")
 
                 return
+
+    @commands.command(name="showinfo", help="get information about a show")
+    async def showinfo_cmd(self, ctx: commands.Context[commands.Bot], *, query: str = "") -> None:
+        if not query:
+            await reply(ctx.message, "usage: !showinfo KEYWORDS...")
+            return
+
+        async with ctx.typing():
+            try:
+                potential = self.sonarr.lookup_series(query)
+            except SonarrError as e:
+                await reply(
+                    ctx.message,
+                    (f"there was an error that isn't <@!{config.discord.admin_id}>'s fault: {e}"),
+                    error=True,
+                )
+                return
+
+            if not potential:
+                await reply(
+                    ctx.message,
+                    f"could not find a show matching the query: {query}",
+                    error=True,
+                )
+                return
+
+        resp, selected = await select_from_list(self.bot, ctx.message, "showinfo", potential)
+
+        if not selected:
+            return
+
+        offers: list[asyncio.Task[None]] = []
+
+        for series in selected:
+            async with ctx.typing():
+                state = self.sonarr.series_state(series)
+                embed = self._build_series_embed(series, state)
+
+            info_msg = await resp.reply(embed=embed)
+
+            if state is MediaState.ABSENT:
+                # each offer waits for a request reaction; run them as tasks so
+                # multiple selections don't wait serially
+                offers.append(asyncio.create_task(self._offer_series_request(info_msg, series)))
+
+        if offers:
+            await asyncio.gather(*offers)
+
+    async def _offer_series_request(self, info_msg: discord.Message, series: Series) -> None:
+        user = await wait_for_request_reaction(self.bot, info_msg)
+
+        if user is None:
+            return
+
+        # !addshow is role-gated, so the reaction shortcut has to be too
+        if not (
+            await member_has_role(user, "plex-admin") or await member_has_role(user, "plex-shows")
+        ):
+            await reply(
+                info_msg,
+                f"{user.display_name}, you don't have permission to do that",
+                error=True,
+            )
+            return
+
+        self.logger.info(f"{user.name} requested the show {series.full_title} via reaction")
+
+        await self._add_series(info_msg, [series], user, announce_requester=True)
+
+    def _series_details(self, series: Series) -> SeriesDetails | None:
+        if self.tmdb is None:
+            return None
+
+        try:
+            return self.tmdb.series_details(series.tvdb_id)
+        except requests.RequestException:
+            self.logger.warning(
+                f"failed to fetch tmdb details for {series.full_title}", exc_info=True
+            )
+            return None
+
+    def _build_series_embed(self, series: Series, state: MediaState) -> discord.Embed:
+        json = series.json
+
+        overview: str = json.get("overview", "")
+
+        embed = discord.Embed(
+            title=series.full_title,
+            url=series.url,
+            description=overview[:1024],
+            color=discord.Color.blue(),
+        )
+
+        if poster := json.get("remotePoster"):
+            embed.set_thumbnail(url=poster)
+
+        if airing := json.get("status"):
+            embed.add_field(name="airing", value=airing, inline=False)
+
+        if network := json.get("network"):
+            embed.add_field(name="network", value=network, inline=False)
+
+        if runtime := json.get("runtime"):
+            embed.add_field(
+                name="runtime", value=f"{format_runtime(runtime)}/episode", inline=False
+            )
+
+        if genres := json.get("genres"):
+            embed.add_field(name="genres", value=", ".join(genres), inline=False)
+
+        if certification := json.get("certification"):
+            embed.add_field(name="rated", value=certification, inline=False)
+
+        seasons = [s for s in json.get("seasons", []) if s.get("seasonNumber", 0) > 0]
+
+        if seasons:
+            embed.add_field(name="seasons", value=str(len(seasons)), inline=False)
+
+        details = self._series_details(series)
+
+        rating_parts: list[str] = []
+
+        # unrated shows report no value (or 0)
+        if value := (json.get("ratings") or {}).get("value"):
+            rating_parts.append(f"tvdb {value:.1f}/10")
+
+        if details is not None and details.rating:
+            rating_parts.append(f"tmdb {details.rating:.1f}/10")
+
+        embed.add_field(
+            name="ratings",
+            value=" | ".join(rating_parts) if rating_parts else "unrated",
+            inline=False,
+        )
+
+        if details is not None:
+            if details.credits.directors:
+                embed.add_field(
+                    name="created by",
+                    value=", ".join(map(str, details.credits.directors)),
+                    inline=False,
+                )
+            if details.credits.cast:
+                embed.add_field(
+                    name="cast", value=", ".join(map(str, details.credits.cast)), inline=False
+                )
+
+        embed.add_field(name="status", value=STATE_LABEL[state], inline=False)
+
+        if state is MediaState.DOWNLOADED:
+            assert series.db_id is not None
+            detail = self.sonarr.get_series_by_id(series.db_id)
+
+            stats = detail.get("statistics") or {}
+
+            if episode_count := stats.get("episodeCount"):
+                embed.add_field(
+                    name="episodes",
+                    value=f"{stats.get('episodeFileCount', 0)}/{episode_count} downloaded",
+                    inline=False,
+                )
+
+            if size := stats.get("sizeOnDisk"):
+                embed.add_field(name="size", value=f"{size / 1024**3:.2f} GB", inline=False)
+        elif state is MediaState.ABSENT:
+            embed.set_footer(text=f"react {REQUEST_EMOJI} to request this show")
+
+        return embed
 
     @commands.command(name="delshow", help="delete a show from the plex")
     @commands.has_any_role("plex-admin", "plex-shows")

--- a/bot/src/wi1_bot/bot/discord/helpers.py
+++ b/bot/src/wi1_bot/bot/discord/helpers.py
@@ -17,6 +17,13 @@ STATE_SUFFIX: dict[MediaState, str] = {
     MediaState.DOWNLOADED: " — **on plex**",
 }
 
+# standalone status labels for info embeds
+STATE_LABEL: dict[MediaState, str] = {
+    MediaState.ABSENT: "not on plex",
+    MediaState.MONITORED: "monitored, not downloaded yet",
+    MediaState.DOWNLOADED: "on plex",
+}
+
 
 async def member_has_role(member: discord.Member | discord.User, role: str) -> bool:
     if isinstance(member, discord.Member):
@@ -25,7 +32,9 @@ async def member_has_role(member: discord.Member | discord.User, role: str) -> b
     return False
 
 
-async def reply(msg: discord.Message, content: str, title: str = "", error: bool = False) -> None:
+async def reply(
+    msg: discord.Message, content: str, title: str = "", error: bool = False
+) -> discord.Message:
     if len(content) > 2048:
         while len(content) > 2048 - len("\n..."):
             content = content[: content.rfind("\n")].rstrip()
@@ -38,7 +47,48 @@ async def reply(msg: discord.Message, content: str, title: str = "", error: bool
         color=discord.Color.red() if error else discord.Color.blue(),
     )
 
-    await msg.reply(embed=embed)
+    return await msg.reply(embed=embed)
+
+
+REQUEST_EMOJI = "📥"
+
+
+async def wait_for_request_reaction(
+    bot: commands.Bot, msg: discord.Message, timeout: float = 120
+) -> discord.Member | discord.User | None:
+    """Seed msg with the request emoji and wait for a user to react with it.
+
+    Returns the first non-bot user to react, or None on timeout (the seeded
+    reaction is removed to show the offer expired).
+    """
+    await msg.add_reaction(REQUEST_EMOJI)
+
+    def check(reaction: discord.Reaction, user: discord.Member | discord.User) -> bool:
+        return (
+            reaction.message.id == msg.id and str(reaction.emoji) == REQUEST_EMOJI and not user.bot
+        )
+
+    try:
+        _, user = await bot.wait_for("reaction_add", check=check, timeout=timeout)
+        return user
+    except asyncio.TimeoutError:
+        assert bot.user is not None
+
+        try:
+            await msg.remove_reaction(REQUEST_EMOJI, bot.user)
+        except discord.HTTPException:
+            pass
+
+        return None
+
+
+def format_runtime(minutes: int) -> str:
+    hours, mins = divmod(minutes, 60)
+
+    if hours == 0:
+        return f"{mins}m"
+
+    return f"{hours}h {mins}m"
 
 
 T = TypeVar("T")

--- a/bot/src/wi1_bot/bot/tmdb.py
+++ b/bot/src/wi1_bot/bot/tmdb.py
@@ -1,0 +1,111 @@
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+from wi1_bot.bot.config import TmdbConfig
+
+BASE_URL = "https://api.themoviedb.org/3"
+
+MAX_CAST = 5
+
+
+@dataclass
+class Person:
+    name: str
+    tmdb_id: int
+    imdb_id: str | None = None
+
+    @property
+    def url(self) -> str:
+        # prefer imdb like Movie/Series do, falling back to the person's tmdb page
+        if self.imdb_id:
+            return f"https://imdb.com/name/{self.imdb_id}"
+
+        return f"https://themoviedb.org/person/{self.tmdb_id}"
+
+    def __str__(self) -> str:
+        return f"[{self.name}]({self.url})"
+
+
+@dataclass
+class Credits:
+    directors: list[Person]  # creators for a series
+    cast: list[Person]
+
+
+@dataclass
+class SeriesDetails:
+    credits: Credits
+    rating: float | None  # tmdb community rating (vote_average), None if unrated
+
+
+class Tmdb:
+    @classmethod
+    def from_config(cls, config: TmdbConfig | None) -> "Tmdb | None":
+        """Build a client from config, or None if tmdb is unset or the api key is
+        still the template placeholder — callers then skip TMDB entirely instead of
+        logging failed queries."""
+        if config is None or "XXX" in config.api_key:
+            return None
+
+        return cls(config.api_key)
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key
+
+    def _get(self, path: str, **params: str) -> dict[str, Any]:
+        resp = requests.get(
+            f"{BASE_URL}{path}", params={"api_key": self._api_key, **params}, timeout=10
+        )
+        resp.raise_for_status()
+
+        json = resp.json()
+        assert isinstance(json, dict)
+        return json
+
+    def _person(self, json: dict[str, Any]) -> Person:
+        """Build a Person, resolving their imdb id (one extra request); on failure the
+        Person just keeps its tmdb fallback url."""
+        person = Person(json["name"], json["id"])
+
+        try:
+            external_ids = self._get(f"/person/{person.tmdb_id}/external_ids")
+        except requests.RequestException:
+            return person
+
+        person.imdb_id = external_ids.get("imdb_id") or None
+
+        return person
+
+    def movie_credits(self, tmdb_id: int) -> Credits:
+        json = self._get(f"/movie/{tmdb_id}/credits")
+
+        directors = [self._person(c) for c in json.get("crew", []) if c.get("job") == "Director"]
+        cast = [self._person(c) for c in json.get("cast", [])[:MAX_CAST]]
+
+        return Credits(directors=directors, cast=cast)
+
+    def series_details(self, tvdb_id: int) -> SeriesDetails | None:
+        """Look up a series' creators, cast and tmdb rating, or None if TMDB doesn't
+        know the TVDB id."""
+        found = self._get(f"/find/{tvdb_id}", external_source="tvdb_id")
+
+        tv_results = found.get("tv_results", [])
+
+        if not tv_results:
+            return None
+
+        tmdb_id: int = tv_results[0]["id"]
+
+        json = self._get(f"/tv/{tmdb_id}", append_to_response="aggregate_credits")
+
+        creators = [self._person(c) for c in json.get("created_by", [])]
+        cast = [
+            self._person(c) for c in json.get("aggregate_credits", {}).get("cast", [])[:MAX_CAST]
+        ]
+
+        # unrated shows report vote_average 0
+        rating = json.get("vote_average") or None
+
+        return SeriesDetails(credits=Credits(directors=creators, cast=cast), rating=rating)

--- a/bot/tests/test_bot_config.py
+++ b/bot/tests/test_bot_config.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from wi1_bot.bot.config import DiscordConfig
+from wi1_bot.bot.config import Config, DiscordConfig
 
 
 class TestQuotaConfig:
@@ -46,3 +46,19 @@ class TestQuotaConfig:
     def test_owner_in_own_with_list_rejected(self) -> None:
         with pytest.raises(ValidationError, match="more than one quota"):
             self._discord({111: {"amount": 10, "with": [111]}})
+
+
+class TestTmdbConfig:
+    def test_tmdb_is_optional(self) -> None:
+        # the shared test config has no tmdb section
+        assert Config().tmdb is None
+
+    def test_tmdb_api_key_parses(self) -> None:
+        cfg = Config(tmdb={"api_key": "abc"})  # type: ignore[arg-type]
+
+        assert cfg.tmdb is not None
+        assert cfg.tmdb.api_key == "abc"
+
+    def test_empty_api_key_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Config(tmdb={"api_key": ""})  # type: ignore[arg-type]

--- a/bot/tests/test_tmdb.py
+++ b/bot/tests/test_tmdb.py
@@ -1,0 +1,139 @@
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from wi1_bot.bot.config import TmdbConfig
+from wi1_bot.bot.tmdb import Person, Tmdb
+
+
+def _mock_response(json: dict[str, Any]) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = json
+    return resp
+
+
+def _fake_get(routes: dict[str, dict[str, Any]]) -> Any:
+    """Return a requests.get stand-in that answers by url fragment; person
+    external_ids requests get imdb id nm<tmdb_id> unless overridden."""
+
+    def fake_get(url: str, params: dict[str, str], timeout: int) -> MagicMock:
+        for fragment, json in routes.items():
+            if fragment in url:
+                return _mock_response(json)
+
+        if "/external_ids" in url:
+            person_id = url.split("/person/")[1].split("/")[0]
+            return _mock_response({"imdb_id": f"nm{person_id}"})
+
+        raise AssertionError(f"unexpected request: {url}")
+
+    return fake_get
+
+
+class TestFromConfig:
+    def test_no_config_returns_none(self) -> None:
+        assert Tmdb.from_config(None) is None
+
+    def test_placeholder_key_returns_none(self) -> None:
+        # unfilled template value: skip TMDB entirely instead of logging failed queries
+        assert Tmdb.from_config(TmdbConfig(api_key="XXX")) is None
+
+    def test_real_key_returns_client(self) -> None:
+        assert isinstance(Tmdb.from_config(TmdbConfig(api_key="real-key")), Tmdb)
+
+
+class TestPerson:
+    def test_prefers_imdb_url(self) -> None:
+        person = Person("Jane Director", 101, imdb_id="nm0000101")
+
+        assert str(person) == "[Jane Director](https://imdb.com/name/nm0000101)"
+
+    def test_falls_back_to_tmdb_url(self) -> None:
+        person = Person("Jane Director", 101)
+
+        assert str(person) == "[Jane Director](https://themoviedb.org/person/101)"
+
+
+class TestMovieCredits:
+    def test_extracts_directors_and_cast(self) -> None:
+        credits_json = {
+            "cast": [{"name": f"Actor {i}", "id": i} for i in range(10)],
+            "crew": [
+                {"name": "Some Editor", "job": "Editor", "id": 100},
+                {"name": "Jane Director", "job": "Director", "id": 101},
+            ],
+        }
+
+        with patch(
+            "wi1_bot.bot.tmdb.requests.get",
+            side_effect=_fake_get({"/movie/123/credits": credits_json}),
+        ):
+            credits = Tmdb("key").movie_credits(123)
+
+        assert credits.directors == [Person("Jane Director", 101, imdb_id="nm101")]
+        # cast is capped at 5
+        assert credits.cast == [Person(f"Actor {i}", i, imdb_id=f"nm{i}") for i in range(5)]
+
+    def test_missing_fields(self) -> None:
+        with patch("wi1_bot.bot.tmdb.requests.get", return_value=_mock_response({})):
+            credits = Tmdb("key").movie_credits(123)
+
+        assert credits.directors == []
+        assert credits.cast == []
+
+    def test_no_imdb_id_keeps_tmdb_fallback(self) -> None:
+        credits_json = {"cast": [{"name": "Obscure Actor", "id": 9}]}
+
+        with patch(
+            "wi1_bot.bot.tmdb.requests.get",
+            side_effect=_fake_get(
+                {"/movie/123/credits": credits_json, "/person/9/external_ids": {"imdb_id": None}}
+            ),
+        ):
+            credits = Tmdb("key").movie_credits(123)
+
+        assert credits.cast == [Person("Obscure Actor", 9, imdb_id=None)]
+        assert "themoviedb.org/person/9" in credits.cast[0].url
+
+
+class TestSeriesDetails:
+    def test_resolves_tvdb_id_then_fetches_details(self) -> None:
+        find_json = {"tv_results": [{"id": 456}]}
+        tv_json = {
+            "created_by": [{"name": "Show Creator", "id": 7}],
+            "aggregate_credits": {"cast": [{"name": "Lead Actor", "id": 8}]},
+            "vote_average": 8.7,
+        }
+
+        with patch(
+            "wi1_bot.bot.tmdb.requests.get",
+            side_effect=_fake_get({"/find/789": find_json, "/tv/456": tv_json}),
+        ) as get:
+            details = Tmdb("key").series_details(789)
+
+        assert details is not None
+        assert details.credits.directors == [Person("Show Creator", 7, imdb_id="nm7")]
+        assert details.credits.cast == [Person("Lead Actor", 8, imdb_id="nm8")]
+        assert details.rating == 8.7
+
+        find_call = get.call_args_list[0]
+        assert "/find/789" in find_call.args[0]
+        assert find_call.kwargs["params"]["external_source"] == "tvdb_id"
+
+    def test_unrated_series_has_no_rating(self) -> None:
+        find_json = {"tv_results": [{"id": 456}]}
+        tv_json = {"vote_average": 0.0}
+
+        with patch(
+            "wi1_bot.bot.tmdb.requests.get",
+            side_effect=_fake_get({"/find/789": find_json, "/tv/456": tv_json}),
+        ):
+            details = Tmdb("key").series_details(789)
+
+        assert details is not None
+        assert details.rating is None
+
+    def test_unknown_tvdb_id_returns_none(self) -> None:
+        with patch(
+            "wi1_bot.bot.tmdb.requests.get", return_value=_mock_response({"tv_results": []})
+        ):
+            assert Tmdb("key").series_details(789) is None

--- a/uv.lock
+++ b/uv.lock
@@ -1480,6 +1480,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
+    { name = "requests" },
 ]
 
 [package.metadata]
@@ -1490,6 +1491,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "requests", specifier = ">=2.31.0" },
 ]
 
 [[package]]

--- a/webhook/src/wi1_bot/webhook/app.py
+++ b/webhook/src/wi1_bot/webhook/app.py
@@ -122,13 +122,7 @@ def index() -> Any:
             case "Test":
                 logger.info("got test event from arr")
             case "Download":
-                if "movieFiles" in request.json or "episodeFiles" in request.json:
-                    logger.debug("ignoring On Import Complete event")
-                    return
-
                 on_download(request.json)
-            case "Grab" | "EpisodeFileDelete" | "Health" | "HealthRestored" as et:
-                logger.debug(f"ignoring {et} event")
             case et:
                 logger.warning(f"handler not setup for event type {et}")
 


### PR DESCRIPTION
Implements the `!movieinfo` TODO from the README (plus a `!showinfo` counterpart).

## Summary

- **`!movieinfo KEYWORDS...` + `!showinfo KEYWORDS...`** — looks up a title via Radarr/Sonarr, presents the same numbered selection as `!addmovie`/`!addshow`, then replies with:
  - poster thumbnail, overview, runtime, genres, studio/network, ratings -
  - IMDb / TMDB / Rotten Tomatoes / Metacritic for movies; TVDB for shows, plus TMDB when a tmdb key is set (`unrated` shown when no source has a value)
  - library status (`not on plex` / `monitored, not downloaded yet` / `on plex`)
  - for downloaded titles: quality + size (movies), episodes downloaded / total + size (shows)
- **React-to-request** — if the title isn't in the library, the bot seeds the embed with a reaction to allow the user to request the title. The first user to react triggers the addition, attributed appropriately for quotas. On timeout, the bot removes the reaction to show the option has expired. 
- **Optional TMDB enrichment** — a new optional `tmdb.api_key` config section (documented in `bot/config.yaml.template`). When enabled, embeds also include director + top-5 cast for movies and creator + cast for shows (TVDB id resolved to
  TMDB via `/find`); each name links to the person's IMDb page (via `/person/{id}/external_ids`), falling back to their TMDB page. When the section is omitted or the key is still the `XXX` template placeholder, TMDB is skipped entirely — no queries, no log noise. Without TMDB, movie credits fall back to Radarr's own stored credits (`/api/v3/credit`, library movies only); Sonarr has no credits endpoint, so shows get cast only via TMDB.
- **Bugfix** — `Movie`/`Series` only handled a *missing* `imdbId` key, but the arr APIs (Sonarr lookups especially) often return it as `""`, producing broken `https://imdb.com/title/` links. Empty is now treated as absent so titles link to IMDb when an id exists and fall back to TMDB/TVDB otherwise — this also fixes the links in the existing `!addmovie`/`!addshow` pickers and replies.

## How it works

- The add-and-tag flow was extracted out of `addmovie_cmd`/`addshow_cmd` into `_add_movies`/`_add_series` so the reaction path reuses it exactly — no behavior change to the existing commands.
- `helpers.reply()` now returns the sent `discord.Message` (previously `None`) so callers can attach reactions; all existing call sites ignore the return value.
- New `wi1_bot.bot.tmdb` module: minimal TMDB v3 client using `requests` (added as an explicit dependency of the `wi1-bot` package; it was already present transitively via pyarr).
- Multiple picker selections watch for request reactions concurrently (`asyncio.create_task` + `gather`), not serially.
- Known limitation: pending reaction offers use `bot.wait_for`, so they don't survive a bot restart (acceptable for a 2-minute window).

### Files changed

| File | Change |
|---|---|
| `bot/src/wi1_bot/bot/discord/cogs/movie.py` | `!movieinfo`, embed builder, `_add_movies` refactor, reaction request flow |
| `bot/src/wi1_bot/bot/discord/cogs/series.py` | `!showinfo`, embed builder, `_add_series` refactor, role-gated reaction request flow |
| `bot/src/wi1_bot/bot/discord/helpers.py` | `reply()` returns the message; `STATE_LABEL`, `REQUEST_EMOJI`, `wait_for_request_reaction()`, `format_runtime()` |
| `bot/src/wi1_bot/bot/tmdb.py` | new — minimal TMDB v3 client (`from_config` placeholder detection, `movie_credits`, `series_details`, `Person` with IMDb-preferred links) |
| `arr/src/wi1_bot/arr/radarr.py` | new `get_movie_credits()` — pyarr has no credit sub-client, so it uses the same `handler.request` escape hatch as `add_tag` |
| `arr/src/wi1_bot/arr/movie.py` / `sonarr.py` | treat `imdbId: ""` as absent (bugfix above) |
| `arr/tests/test_arr_models.py` / `test_arr_integration.py` | new `TestSeries` class, empty-`imdbId` regression tests, `get_movie_credits` test |
| `bot/src/wi1_bot/bot/config.py` | new optional `TmdbConfig` (`tmdb.api_key`) |
| `bot/config.yaml.template` | document the optional `tmdb` section |
| `bot/pyproject.toml` / `uv.lock` | add `requests>=2.31.0` to the bot package |
| `bot/tests/test_tmdb.py` | new — TMDB client parsing + TVDB→TMDB resolution tests |
| `bot/tests/test_bot_config.py` | tests for the optional tmdb config toggle |

